### PR TITLE
Add new arithmetic instructions to all interpreter variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,14 @@ COMPILE.c = $(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -c
 POSTCOMPILE = mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d
 
 %.o: %.c $(DEPDIR)/%.d
-	$(COMPILE.c) $(OUTPUT_OPTION) $<
+	$(COMPILE.c) $(OUTPUT_OPTION) $< 
 	$(POSTCOMPILE)
 
 $(DEPDIR)/%.d: ;
 .PRECIOUS: $(DEPDIR)/%.d
 -include $(patsubst %,$(DEPDIR)/%.d,$(basename $(ALL_SRCS)))
 
-$(ALL): $(COMMON_OBJ)
+$(ALL): $(COMMON_OBJ) -lm
 
 # #######################
 # Individual applications

--- a/common.c
+++ b/common.c
@@ -64,8 +64,9 @@ const Instr_t Primes[PROGRAM_SIZE] = {
 
 const Instr_t Instr_Rot_Test[PROGRAM_SIZE] = {
     Instr_Push, 1,
-    Instr_Push, 5,
-    Instr_Push, 8,
+    Instr_Push, 2,
+    Instr_Push, 3,
+    Instr_Push, 4,
     Instr_Rot,
     Instr_Halt
 };
@@ -98,9 +99,27 @@ const Instr_t Instr_SHx_Test[PROGRAM_SIZE] = {
    Instr_Halt
 };
 
+const Instr_t Instr_SQRT_Test[PROGRAM_SIZE] = {
+   Instr_Push, 9,
+   Instr_SQRT,
+   Instr_Halt
+};
+
+const Instr_t Instr_Pick_Test[PROGRAM_SIZE] = {
+   Instr_Push, 1,
+   Instr_Push, 2,
+   Instr_Push, 3,
+   Instr_Push, 4,
+   Instr_Push, 0,
+   Instr_Push, 5,
+   Instr_Push, 3,
+   Instr_Pick,
+   Instr_Halt
+};
+
 /* Choose a program we are about to simulate */
 //const Instr_t* Program = Primes;
-const Instr_t* Program = Instr_SHx_Test;
+const Instr_t* Program = Instr_Pick_Test;
 
 /* Other programs, kept here just for reference */
 const Instr_t OldProgram[PROGRAM_SIZE] = {

--- a/common.c
+++ b/common.c
@@ -62,8 +62,45 @@ const Instr_t Primes[PROGRAM_SIZE] = {
     Instr_Halt           // nmax, c (== nmax)
 };
 
+const Instr_t Instr_Rot_Test[PROGRAM_SIZE] = {
+    Instr_Push, 1,
+    Instr_Push, 5,
+    Instr_Push, 8,
+    Instr_Rot,
+    Instr_Halt
+};
+
+const Instr_t Instr_Logic_Test[PROGRAM_SIZE] = {
+   Instr_Push, 1,
+   Instr_Push, 2,
+   Instr_Xor,
+   Instr_Print,
+   Instr_Push, 1,
+   Instr_Push, 2,
+   Instr_Or,
+   Instr_Print,
+   Instr_Push, 1,
+   Instr_Push, 2,
+   Instr_And,
+   Instr_Print,
+   Instr_Halt
+};
+
+const Instr_t Instr_SHx_Test[PROGRAM_SIZE] = {
+   Instr_Push, 1,
+   Instr_Push, 3,
+   Instr_SHL,
+   Instr_Print,
+   Instr_Push, 1,
+   Instr_Push, 3,
+   Instr_SHR,
+   Instr_Print,
+   Instr_Halt
+};
+
 /* Choose a program we are about to simulate */
-const Instr_t* Program = Primes;
+//const Instr_t* Program = Primes;
+const Instr_t* Program = Instr_SHx_Test;
 
 /* Other programs, kept here just for reference */
 const Instr_t OldProgram[PROGRAM_SIZE] = {
@@ -105,3 +142,5 @@ const Instr_t Factorial[PROGRAM_SIZE] = {
     Instr_Print,    // n
     Instr_Halt
 };
+
+

--- a/common.h
+++ b/common.h
@@ -59,6 +59,14 @@ Instr_Drop   = 0x000f,
 Instr_Over   = 0x0010,
 Instr_Mod    = 0x0011,
 Instr_Jump   = 0x0012, /* imm */
+Instr_And    = 0x0013,
+Instr_Or     = 0x0014,
+Instr_Xor    = 0x0015,
+Instr_SHL    = 0x0016,
+Instr_SHR    = 0x0017,
+Instr_SQRT   = 0x0018,
+Instr_Rot    = 0x0019,
+Instr_Pick   = 0x001a,
 
 };
 

--- a/predecoded.c
+++ b/predecoded.c
@@ -56,6 +56,12 @@ static inline decode_t decode_at_address(const Instr_t* prog, uint32_t addr) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -137,7 +143,7 @@ int main(int argc, char **argv) {
             break;
         }
         decode_t decoded = decoded_cache[cpu.pc];
-        uint32_t tmp1 = 0, tmp2 = 0;
+        uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
         /* Execute - a big switch */
         switch(decoded.opcode) {
         case Instr_Nop:
@@ -234,6 +240,46 @@ int main(int argc, char **argv) {
         case Instr_Jump:
             cpu.pc += decoded.immediate;
             break;
+        case Instr_And:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 & tmp2);
+            break;
+        case Instr_Or:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 | tmp2);
+            break;
+        case Instr_Xor:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 ^ tmp2);
+            break;
+        case Instr_SHL:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 << tmp2);
+            break;
+        case Instr_SHR:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 >> tmp2);
+            break;
+        case Instr_Rot:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            tmp3 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1);
+            push(&cpu, tmp3);
+            push(&cpu, tmp2);
+            break;
+
         case Instr_Break:
             cpu.state = Cpu_Break;
             break;

--- a/subroutined.c
+++ b/subroutined.c
@@ -328,7 +328,7 @@ service_routine_t service_routines[] = {
         &sr_Add, &sr_Sub, &sr_Mul, &sr_Rand, &sr_Dec,
         &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump,
         &sr_And, &sr_Or, &sr_Xor,
-        &sr_SHR, &sr_SHL,
+        &sr_SHL, &sr_SHR,
         &sr_SQRT,
         &sr_Rot, &sr_Pick
     };

--- a/subroutined.c
+++ b/subroutined.c
@@ -73,6 +73,12 @@ static inline decode_t decode(Instr_t raw_instr, const cpu_t *pcpu) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -236,6 +242,51 @@ void sr_Jne(cpu_t *pcpu, decode_t *pdecoded) {
         pcpu->pc += pdecoded->immediate;
 }
 
+void sr_And(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 & tmp2);
+}
+
+void sr_Or(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 | tmp2);
+}
+
+void sr_Xor(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 ^ tmp2);
+}
+
+void sr_SHL(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 << tmp2);
+}
+
+void sr_SHR(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 >> tmp2);
+}
+
+void sr_Rot(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    uint32_t tmp3 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1);
+    push(pcpu, tmp3);
+    push(pcpu, tmp2);
+}
+
 void sr_Jump(cpu_t *pcpu, decode_t *pdecoded) {
     pcpu->pc += pdecoded->immediate;
 }
@@ -250,7 +301,10 @@ service_routine_t service_routines[] = {
         &sr_Break, &sr_Nop, &sr_Halt, &sr_Push, &sr_Print,
         &sr_Jne, &sr_Swap, &sr_Dup, &sr_Je, &sr_Inc,
         &sr_Add, &sr_Sub, &sr_Mul, &sr_Rand, &sr_Dec,
-        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump
+        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump,
+        &sr_And, &sr_Or, &sr_Xor,
+        &sr_SHR, &sr_SHL,
+        &sr_Rot
     };
 
 int main(int argc, char **argv) {    

--- a/switched.c
+++ b/switched.c
@@ -70,6 +70,13 @@ static inline decode_t decode(Instr_t raw_instr, const cpu_t *pcpu) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    /* Added instructions */
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -137,7 +144,7 @@ int main(int argc, char **argv) {
         BAIL_ON_ERROR();
         decode_t decoded = decode(raw_instr, &cpu);
         
-        uint32_t tmp1 = 0, tmp2 = 0;
+        uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
         /* Execute - a big switch */
         switch(decoded.opcode) {
         case Instr_Nop:
@@ -233,6 +240,45 @@ int main(int argc, char **argv) {
             break;
         case Instr_Jump:
             cpu.pc += decoded.immediate;
+            break;
+        case Instr_And:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 & tmp2);
+            break;
+        case Instr_Or:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 | tmp2);
+            break;
+        case Instr_Xor:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 ^ tmp2);
+            break;
+        case Instr_SHL:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 << tmp2);
+            break;
+        case Instr_SHR:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 >> tmp2);
+            break;
+        case Instr_Rot:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            tmp3 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1);
+            push(&cpu, tmp3);
+            push(&cpu, tmp2);
             break;
         case Instr_Break:
             cpu.state = Cpu_Break;

--- a/tailrecursive.c
+++ b/tailrecursive.c
@@ -74,6 +74,12 @@ static inline decode_t decode(Instr_t raw_instr, const cpu_t *pcpu) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -302,6 +308,69 @@ void sr_Jump(cpu_t *pcpu, decode_t *pdecoded) {
     DISPATCH();
 }
 
+void sr_And(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 & tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_Or(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 | tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_Xor(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 ^ tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_SHL(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 << tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_SHR(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1 >> tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_Rot(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    uint32_t tmp3 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, tmp1);
+    push(pcpu, tmp3);
+    push(pcpu, tmp2);
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
 void sr_Break(cpu_t *pcpu, decode_t *pdecoded) {
     pcpu->state = Cpu_Break;
     ADVANCE_PC();
@@ -313,7 +382,10 @@ service_routine_t service_routines[] = {
         &sr_Break, &sr_Nop, &sr_Halt, &sr_Push, &sr_Print,
         &sr_Jne, &sr_Swap, &sr_Dup, &sr_Je, &sr_Inc,
         &sr_Add, &sr_Sub, &sr_Mul, &sr_Rand, &sr_Dec,
-        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump
+        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump,
+        &sr_And, &sr_Or, &sr_Xor,
+        &sr_SHL, &sr_SHR,
+        &sr_Rot
     };
 
 int main(int argc, char **argv) {    

--- a/tailrecursive.c
+++ b/tailrecursive.c
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 #include <stdlib.h>
 #include <errno.h>
 #include <limits.h>
+#include <math.h>
 
 #include "common.h"
 
@@ -80,6 +81,8 @@ static inline decode_t decode(Instr_t raw_instr, const cpu_t *pcpu) {
     case Instr_SHL:
     case Instr_SHR:
     case Instr_Rot:
+    case Instr_SQRT:
+    case Instr_Pick:
         result.length = 1;
         break;
     case Instr_Push:
@@ -137,6 +140,16 @@ static inline uint32_t pop(cpu_t *pcpu) {
         return 0;
     }
     return pcpu->stack[pcpu->sp--];
+}
+
+static inline uint32_t pick(cpu_t *pcpu, int32_t pos) {
+    assert(pcpu);
+    if (pcpu->sp - 1 < pos) {
+        printf("Out of bound picking\n");
+        pcpu->state = Cpu_Break;
+        return 0;
+    }
+    return pcpu->stack[pcpu->sp - pos];
 }
 
 typedef void (*service_routine_t)(cpu_t *pcpu, decode_t* pdecode);
@@ -371,6 +384,24 @@ void sr_Rot(cpu_t *pcpu, decode_t *pdecoded) {
     DISPATCH();
 }
 
+void sr_SQRT(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, sqrt(tmp1));
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
+void sr_Pick(cpu_t *pcpu, decode_t *pdecoded) {
+    uint32_t tmp1 = pop(pcpu);
+    BAIL_ON_ERROR();
+    push(pcpu, pick(pcpu, tmp1));
+    ADVANCE_PC();
+    *pdecoded = fetch_decode(pcpu);
+    DISPATCH();
+}
+
 void sr_Break(cpu_t *pcpu, decode_t *pdecoded) {
     pcpu->state = Cpu_Break;
     ADVANCE_PC();
@@ -385,7 +416,9 @@ service_routine_t service_routines[] = {
         &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump,
         &sr_And, &sr_Or, &sr_Xor,
         &sr_SHL, &sr_SHR,
-        &sr_Rot
+        &sr_SQRT,
+        &sr_Rot,
+        &sr_Pick
     };
 
 int main(int argc, char **argv) {    

--- a/threaded-cached.c
+++ b/threaded-cached.c
@@ -57,6 +57,12 @@ static inline decode_t decode_at_address(const Instr_t* prog, uint32_t addr) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -135,7 +141,10 @@ int main(int argc, char **argv) {
         &&sr_Break, &&sr_Nop, &&sr_Halt, &&sr_Push, &&sr_Print,
         &&sr_Jne, &&sr_Swap, &&sr_Dup, &&sr_Je, &&sr_Inc,
         &&sr_Add, &&sr_Sub, &&sr_Mul, &&sr_Rand, &&sr_Dec,
-        &&sr_Drop, &&sr_Over, &&sr_Mod, &&sr_Jump, NULL /* This NULL seems to be essential to keep GCC from over-optimizing? */
+        &&sr_Drop, &&sr_Over, &&sr_Mod, &&sr_Jump,
+        &&sr_And, &&sr_Or, &&sr_Xor,
+        &&sr_SHL, &&sr_SHR,
+        &&sr_Rot, NULL /* This NULL seems to be essential to keep GCC from over-optimizing? */
     };
     long long steplimit = LLONG_MAX;
     if (argc > 1) {
@@ -153,7 +162,7 @@ int main(int argc, char **argv) {
     decode_t decoded_cache[PROGRAM_SIZE];
     predecode_program(cpu.pmem, service_routines, decoded_cache, PROGRAM_SIZE);
     
-    uint32_t tmp1 = 0, tmp2 = 0;
+    uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
     decode_t decoded = {0};
     do {
         DISPATCH();
@@ -267,6 +276,51 @@ int main(int argc, char **argv) {
             DISPATCH();
         sr_Jump:
             cpu.pc += decoded.immediate;
+            ADVANCE_PC();
+            DISPATCH();
+        sr_And:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 & tmp2);
+            ADVANCE_PC();
+            DISPATCH();
+        sr_Or:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 | tmp2);
+            ADVANCE_PC();
+            DISPATCH();
+        sr_Xor:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 ^ tmp2);
+            ADVANCE_PC();
+            DISPATCH();
+        sr_SHL:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 << tmp2);
+            ADVANCE_PC();
+            DISPATCH();
+        sr_SHR:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 >> tmp2);
+            ADVANCE_PC();
+            DISPATCH();
+        sr_Rot:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            tmp3 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1);
+            push(&cpu, tmp3);
+            push(&cpu, tmp2);
             ADVANCE_PC();
             DISPATCH();
         sr_Break:

--- a/threaded.c
+++ b/threaded.c
@@ -70,6 +70,12 @@ static inline decode_t decode(Instr_t raw_instr, const cpu_t *pcpu) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -145,7 +151,10 @@ int main(int argc, char **argv) {
         &&sr_Break, &&sr_Nop, &&sr_Halt, &&sr_Push, &&sr_Print,
         &&sr_Jne, &&sr_Swap, &&sr_Dup, &&sr_Je, &&sr_Inc,
         &&sr_Add, &&sr_Sub, &&sr_Mul, &&sr_Rand, &&sr_Dec,
-        &&sr_Drop, &&sr_Over, &&sr_Mod, &&sr_Jump, NULL /* This NULL seems to be essential to keep GCC from over-optimizing? */
+        &&sr_Drop, &&sr_Over, &&sr_Mod, &&sr_Jump, 
+        &&sr_And, &&sr_Or, &&sr_Xor,
+        &&sr_SHL, &&sr_SHR,
+        &&sr_Rot, NULL /* This NULL seems to be essential to keep GCC from over-optimizing? */
     };
     
     long long steplimit = LLONG_MAX;
@@ -294,6 +303,57 @@ int main(int argc, char **argv) {
             DISPATCH();
         sr_Jump:
             cpu.pc += decoded.immediate;
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_And:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 & tmp2);
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_Or:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 | tmp2);
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_Xor:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 ^ tmp2);
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_SHL:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 << tmp2);
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_SHR:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1 >> tmp2);
+            ADVANCE_PC();
+            decoded = fetch_decode(&cpu);
+            DISPATCH();
+        sr_Rot:
+            tmp1 = pop(&cpu);
+            tmp2 = pop(&cpu);
+            tmp3 = pop(&cpu);
+            BAIL_ON_ERROR();
+            push(&cpu, tmp1);
+            push(&cpu, tmp3);
+            push(&cpu, tmp2);
             ADVANCE_PC();
             decoded = fetch_decode(&cpu);
             DISPATCH();

--- a/translated.c
+++ b/translated.c
@@ -83,6 +83,12 @@ static inline decode_t decode_at_address(const Instr_t* prog, uint32_t addr) {
     case Instr_Drop:
     case Instr_Over:
     case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
         result.length = 1;
         break;
     case Instr_Push:
@@ -267,6 +273,51 @@ void sr_Jump(int32_t immediate) {
     exit_generated_code();    
 }
 
+void sr_And() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    push(pcpu, tmp1 & tmp2);
+    ADVANCE_PC(1);
+}
+
+void sr_Or() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    push(pcpu, tmp1 | tmp2);
+    ADVANCE_PC(1);
+}
+
+void sr_Xor() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    push(pcpu, tmp1 ^ tmp2);
+    ADVANCE_PC(1);
+}
+
+void sr_SHL() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    push(pcpu, tmp1 << tmp2);
+    ADVANCE_PC(1);
+}
+
+void sr_SHR() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    push(pcpu, tmp1 >> tmp2);
+    ADVANCE_PC(1);
+}
+
+void sr_Rot() {
+    uint32_t tmp1 = pop(pcpu);
+    uint32_t tmp2 = pop(pcpu);
+    uint32_t tmp3 = pop(pcpu);
+    push(pcpu, tmp1);
+    push(pcpu, tmp3);
+    push(pcpu, tmp2);
+    ADVANCE_PC(1);
+}
+
 void sr_Break() {
     pcpu->state = Cpu_Break;
     ADVANCE_PC(1);
@@ -277,7 +328,10 @@ const service_routine_t service_routines[] = {
         &sr_Break, &sr_Nop, &sr_Halt, &sr_Push, &sr_Print,
         &sr_Jne, &sr_Swap, &sr_Dup, &sr_Je, &sr_Inc,
         &sr_Add, &sr_Sub, &sr_Mul, &sr_Rand, &sr_Dec,
-        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump
+        &sr_Drop, &sr_Over, &sr_Mod, &sr_Jump,
+        &sr_And, &sr_Or, &sr_Xor,
+        &sr_SHL, &sr_SHR,
+        &sr_Rot
     };
 
 static void translate_program(const Instr_t *prog,


### PR DESCRIPTION
Instructions are tested on sample programs(common.c). Check out consequences if &&sr_SHL and && sr_SHR are swapped in definition(subroutined.c).
